### PR TITLE
Re-add page loaded to avoid compile failures when building old commits that depend on test-selenium

### DIFF
--- a/src/main/java/com/liferay/faces/test/selenium/expectedconditions/PageLoaded.java
+++ b/src/main/java/com/liferay/faces/test/selenium/expectedconditions/PageLoaded.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.test.selenium.expectedconditions;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+
+
+/**
+ * @author      Kyle Stiemann
+ * @deprecated  This class is unnecessary since selenium normally attempts to wait for pages to load. See {@link
+ *              WebDriver} and {@link WebDriver#get(java.lang.String)} for more details.
+ */
+@Deprecated
+public class PageLoaded implements ExpectedCondition<Boolean> {
+
+	@Override
+	public Boolean apply(WebDriver webDriver) {
+
+		JavascriptExecutor javascriptExecutor = (JavascriptExecutor) webDriver;
+		String readyState = (String) javascriptExecutor.executeScript("return document.readyState");
+
+		return "complete".equals(readyState);
+	}
+}


### PR DESCRIPTION
@ngriffin7a,
<sup>(/cc @vsingleton, @pcwhite, so they can see the dangers of breaking changes even for projects that are designed to be used internally)</sup>
Since we'll soon be making breaking changes to the `test-selenium` jar, I've realized we are setting ourselves up for serious problems in the future if we don't follow something at least similar to semantic versioning. The issue is that many commits for many of our repos depend on `test-selenium` `0.2.0-SNAPSHOT` in order to be built correctly. In the future, if we ever want to come back and rebuild those commits, we will need `0.2.0-SNAPSHOT` to contain all possible methods and classes to avoid a compile failure. This PR tries to make that happen.

Please:

1. Merge this PR and push to ensure the last ever version of `0.2.0-SNAPSHOT` contains all classes so that all commits that depend on it will be built. **It's important that this step is completed before step 2** to ensure that the final ever `SNAPSHOT` release of `0.2.0-SNAPSHOT` contains every single class and method that was ever contained in any `test-selenium` `0.2.0-SNAPSHOT` version.
2. Release version `0.2.0`.
3. Change the version to `0.3.0-SNAPSHOT` **in this jar only**. I will fix all the jars that depend on this later.

After that I'll start ripping stuff out for `0.3.0-SNAPSHOT`.

Thanks.